### PR TITLE
Fix generate_more_errors; add script to periodically poll metrics

### DIFF
--- a/generate_more_errors.sh
+++ b/generate_more_errors.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 for i in {1..110}; do
-  curl -s http://localhost:8095/error > /dev/null
+  curl -s http://localhost:8097/error > /dev/null
   echo "Generated error $i"
 done

--- a/poll_metrics.sh
+++ b/poll_metrics.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Use the first script argument as sleep time, default to 5 seconds if not provided
+SLEEP_TIME=${1:-5}
+
+while true; do
+  # Fetch metrics and prepend a timestamp to each line
+  curl -s http://localhost:8097/metrics | sed "s/^/[$(date '+%Y-%m-%d %H:%M:%S')] /"
+  echo
+  # Wait for the configured sleep time before polling again
+  sleep "$SLEEP_TIME"
+done


### PR DESCRIPTION
- Fix wrong port for generate_more_errors.sh
- Add script to poll `/metrics` endpoint continuously

```
# defaults to 5s
./poll_metrics.sh 

# or run script with an input in seconds
./poll_metrics.sh 1
```